### PR TITLE
Implement statistics screen and shared time range

### DIFF
--- a/app/src/main/java/sl/kacinz/onluanmer/data/local/dao/TransactionDao.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/data/local/dao/TransactionDao.kt
@@ -12,6 +12,9 @@ interface TransactionDao {
     @Query("SELECT * FROM transactions WHERE goalId = :goalId ORDER BY id DESC")
     fun getTransactions(goalId: Int): Flow<List<Transaction>>
 
+    @Query("SELECT * FROM transactions ORDER BY id DESC")
+    fun getAllTransactions(): Flow<List<Transaction>>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertTransaction(transaction: Transaction)
 }

--- a/app/src/main/java/sl/kacinz/onluanmer/data/repository/TransactionRepositoryImpl.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/data/repository/TransactionRepositoryImpl.kt
@@ -10,5 +10,6 @@ class TransactionRepositoryImpl @Inject constructor(
     private val dao: TransactionDao
 ) : TransactionRepository {
     override fun getTransactions(goalId: Int): Flow<List<Transaction>> = dao.getTransactions(goalId)
+    override fun getAllTransactions(): Flow<List<Transaction>> = dao.getAllTransactions()
     override suspend fun insertTransaction(transaction: Transaction) = dao.insertTransaction(transaction)
 }

--- a/app/src/main/java/sl/kacinz/onluanmer/domain/repository/TransactionRepository.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/domain/repository/TransactionRepository.kt
@@ -5,5 +5,6 @@ import sl.kacinz.onluanmer.domain.model.Transaction
 
 interface TransactionRepository {
     fun getTransactions(goalId: Int): Flow<List<Transaction>>
+    fun getAllTransactions(): Flow<List<Transaction>>
     suspend fun insertTransaction(transaction: Transaction)
 }

--- a/app/src/main/java/sl/kacinz/onluanmer/domain/usecase/GetAllTransactionsUseCase.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/domain/usecase/GetAllTransactionsUseCase.kt
@@ -1,0 +1,12 @@
+package sl.kacinz.onluanmer.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import sl.kacinz.onluanmer.domain.model.Transaction
+import sl.kacinz.onluanmer.domain.repository.TransactionRepository
+import javax.inject.Inject
+
+class GetAllTransactionsUseCase @Inject constructor(
+    private val repository: TransactionRepository
+) {
+    operator fun invoke(): Flow<List<Transaction>> = repository.getAllTransactions()
+}

--- a/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/adapters/MonthAdapter.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/adapters/MonthAdapter.kt
@@ -1,0 +1,33 @@
+package sl.kacinz.onluanmer.presentation.ui.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import sl.kacinz.onluanmer.databinding.ItemMonthBinding
+
+data class MonthAmount(val name: String, val amount: Int)
+
+class MonthAdapter : ListAdapter<MonthAmount, MonthAdapter.MonthViewHolder>(DiffCallback) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MonthViewHolder {
+        val binding = ItemMonthBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return MonthViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: MonthViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class MonthViewHolder(private val binding: ItemMonthBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: MonthAmount) {
+            binding.tvMonth.text = item.name
+            binding.tvAmount.text = "${item.amount}$"
+        }
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<MonthAmount>() {
+        override fun areItemsTheSame(oldItem: MonthAmount, newItem: MonthAmount): Boolean = oldItem.name == newItem.name
+        override fun areContentsTheSame(oldItem: MonthAmount, newItem: MonthAmount): Boolean = oldItem == newItem
+    }
+}

--- a/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/ProgressFragment.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/ProgressFragment.kt
@@ -26,6 +26,7 @@ import sl.kacinz.onluanmer.R
 import sl.kacinz.onluanmer.databinding.FragmentProgressBinding
 import sl.kacinz.onluanmer.domain.model.Transaction
 import sl.kacinz.onluanmer.presentation.ui.fragments.viewmodels.ProgressViewModel
+import sl.kacinz.onluanmer.utils.TimeRange
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -193,10 +194,4 @@ class ProgressFragment : Fragment() {
         _binding = null
     }
 
-    enum class TimeRange(val label: String, val days: Long?) {
-        LAST_WEEK("Last week", 7),
-        LAST_MONTH("Last month", 30),
-        LAST_YEAR("Last year", 365),
-        ALL_TIME("All time", null)
-    }
 }

--- a/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/StatisticsFragment.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/StatisticsFragment.kt
@@ -1,38 +1,206 @@
 package sl.kacinz.onluanmer.presentation.ui.fragments.main
 
+import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.OnBackPressedCallback
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
+import com.github.mikephil.charting.components.Description
+import com.github.mikephil.charting.components.XAxis
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.data.LineData
+import com.github.mikephil.charting.data.LineDataSet
+import com.github.mikephil.charting.formatter.IndexAxisValueFormatter
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import sl.kacinz.onluanmer.R
 import sl.kacinz.onluanmer.databinding.FragmentStatisticsBinding
+import sl.kacinz.onluanmer.domain.model.Transaction
+import sl.kacinz.onluanmer.presentation.ui.adapters.MonthAdapter
+import sl.kacinz.onluanmer.presentation.ui.adapters.MonthAmount
+import sl.kacinz.onluanmer.presentation.ui.fragments.viewmodels.StatisticsViewModel
+import sl.kacinz.onluanmer.utils.TimeRange
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
 
-
+@AndroidEntryPoint
 class StatisticsFragment : Fragment() {
 
-    private lateinit var binding: FragmentStatisticsBinding
+    private var _binding: FragmentStatisticsBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: StatisticsViewModel by viewModels()
+    private val formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
+    private val ranges = listOf(
+        TimeRange.LAST_WEEK,
+        TimeRange.LAST_MONTH,
+        TimeRange.LAST_YEAR,
+        TimeRange.ALL_TIME
+    )
+    private var rangeIndex = 1
+
+    private var allTransactions: List<Transaction> = emptyList()
+
+    private val monthAdapter = MonthAdapter()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentStatisticsBinding.inflate(inflater,container,false)
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentStatisticsBinding.inflate(inflater, container, false)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                findNavController().navigate(R.id.goalListFragment)
-            }
-        })
+        binding.rvTopMonths.adapter = monthAdapter
+        binding.btnPrev.setOnClickListener { changeRange(-1) }
+        binding.btnNext.setOnClickListener { changeRange(1) }
+        binding.tvRange.text = ranges[rangeIndex].label
+        binding.btnBack.setOnClickListener { findNavController().popBackStack() }
 
-        binding.btnBack.setOnClickListener {
-            findNavController().popBackStack(R.id.goalListFragment, false)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.transactions.collect { list ->
+                        allTransactions = list
+                        updateForRange()
+                    }
+                }
+                launch {
+                    viewModel.goals.collect { goals ->
+                        val total = goals.sumOf { it.currentAmount }
+                        val active = goals.count { it.currentAmount < it.targetAmount }
+                        binding.tvTotalFunds.text = "$total$"
+                        binding.tvActiveGoals.text = active.toString()
+                    }
+                }
+            }
         }
+    }
+
+    private fun changeRange(delta: Int) {
+        rangeIndex = (rangeIndex + delta + ranges.size) % ranges.size
+        binding.tvRange.text = ranges[rangeIndex].label
+        updateForRange()
+    }
+
+    private fun updateForRange() {
+        val filtered = filterTransactions(allTransactions, ranges[rangeIndex])
+        updateChart(filtered)
+        updateMetrics(filtered)
+    }
+
+    private fun filterTransactions(
+        transactions: List<Transaction>,
+        range: TimeRange,
+    ): List<Transaction> {
+        if (range.days == null) return transactions
+        val cutoff = LocalDate.now().minusDays(range.days)
+        return transactions.filter {
+            val date = LocalDate.parse(it.date, formatter)
+            !date.isBefore(cutoff)
+        }
+    }
+
+    private fun updateMetrics(transactions: List<Transaction>) {
+        val deposits = transactions.filter { it.amount > 0 }
+        val avgTxn = if (deposits.isNotEmpty()) deposits.map { it.amount }.average() else 0.0
+
+        // Monthly totals
+        val monthly = deposits.groupBy {
+            val date = LocalDate.parse(it.date, formatter)
+            YearMonth.from(date)
+        }.map { (ym, list) ->
+            val sum = list.sumOf { it.amount }
+            val name = ym.month.name.lowercase().replaceFirstChar { c -> c.titlecase() } + " " + ym.year
+            MonthAmount(name, sum)
+        }.sortedByDescending { it.amount }
+
+        monthAdapter.submitList(monthly.take(3))
+
+        val avgMonth = if (monthly.isNotEmpty()) monthly.map { it.amount }.average() else 0.0
+
+        binding.tvAvgPerTxn.text = String.format("%.1f$", avgTxn)
+        binding.tvAvgPerMonth.text = String.format("%.1f$", avgMonth)
+    }
+
+    private fun updateChart(transactions: List<Transaction>) {
+        val sorted = transactions.sortedBy { LocalDate.parse(it.date, formatter) }
+        val entries = mutableListOf<Entry>()
+        val labels = mutableListOf<String>()
+        var sum = 0f
+        sorted.forEachIndexed { i, tx ->
+            sum += tx.amount
+            entries.add(Entry(i.toFloat(), sum))
+            labels.add(tx.date.substring(0,5))
+        }
+
+        val dataSet = LineDataSet(entries, "").apply {
+            setDrawValues(false)
+            mode = LineDataSet.Mode.LINEAR
+            color = Color.parseColor("#FEDD32")
+            lineWidth = 2f
+            setDrawCircles(true)
+            circleRadius = 6f
+            circleHoleRadius = 3f
+            setCircleColor(Color.parseColor("#FEDD32"))
+            circleHoleColor = Color.WHITE
+            setDrawFilled(true)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                fillDrawable = ContextCompat.getDrawable(requireContext(), R.drawable.gradient_chart_fill)
+            } else {
+                fillColor = Color.parseColor("#FEDD32")
+                fillAlpha = 80
+            }
+        }
+
+        binding.lineChart.apply {
+            data = LineData(dataSet)
+            setBackgroundColor(Color.parseColor("#001443"))
+            setDrawGridBackground(false)
+            setTouchEnabled(false)
+            axisRight.isEnabled = false
+            legend.isEnabled = false
+            description = Description().apply {
+                text = "Amount of savings"
+                textColor = Color.WHITE
+                textSize = 14f
+                setPosition(10f,15f)
+            }
+            xAxis.apply {
+                position = XAxis.XAxisPosition.BOTTOM
+                valueFormatter = IndexAxisValueFormatter(labels)
+                granularity = 1f
+                textColor = Color.WHITE
+                textSize = 12f
+                setDrawGridLines(true)
+                gridColor = Color.parseColor("#445270")
+                axisLineColor = Color.parseColor("#445270")
+            }
+            axisLeft.apply {
+                textColor = Color.WHITE
+                textSize = 12f
+                setDrawGridLines(true)
+                gridColor = Color.parseColor("#445270")
+                axisLineColor = Color.parseColor("#445270")
+            }
+            animateX(500)
+            invalidate()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/viewmodels/StatisticsViewModel.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/viewmodels/StatisticsViewModel.kt
@@ -1,0 +1,25 @@
+package sl.kacinz.onluanmer.presentation.ui.fragments.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import sl.kacinz.onluanmer.domain.model.Goal
+import sl.kacinz.onluanmer.domain.model.Transaction
+import sl.kacinz.onluanmer.domain.usecase.GetAllTransactionsUseCase
+import sl.kacinz.onluanmer.domain.usecase.GetGoalsUseCase
+import javax.inject.Inject
+
+@HiltViewModel
+class StatisticsViewModel @Inject constructor(
+    getGoalsUseCase: GetGoalsUseCase,
+    getAllTransactionsUseCase: GetAllTransactionsUseCase
+) : ViewModel() {
+    val goals: StateFlow<List<Goal>> = getGoalsUseCase()
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    val transactions: StateFlow<List<Transaction>> = getAllTransactionsUseCase()
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+}

--- a/app/src/main/java/sl/kacinz/onluanmer/utils/TimeRange.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/utils/TimeRange.kt
@@ -1,0 +1,8 @@
+package sl.kacinz.onluanmer.utils
+
+enum class TimeRange(val label: String, val days: Long?) {
+    LAST_WEEK("Last week", 7),
+    LAST_MONTH("Last month", 30),
+    LAST_YEAR("Last year", 365),
+    ALL_TIME("All time", null)
+}

--- a/app/src/main/res/layout/item_month.xml
+++ b/app/src/main/res/layout/item_month.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/tvMonth"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="May 2025"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/tvAmount"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="1200$"
+        android:textColor="#FEDD32"
+        android:textSize="16sp"
+        android:textStyle="bold" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add `TimeRange` enum for shared period switch
- support querying all transactions
- add viewmodel and adapter for statistics screen
- implement statistics fragment logic and sample layout item

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bef6fed4832a9beb3972e00ca6d0