### PR TITLE
Fix transaction saving race

### DIFF
--- a/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/AddTransactionFragment.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/AddTransactionFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import sl.kacinz.onluanmer.databinding.FragmentAddTransactionBinding
 import sl.kacinz.onluanmer.domain.model.Transaction
@@ -58,13 +59,14 @@ class AddTransactionFragment : Fragment() {
             comment = comment,
             date = binding.tvDate.text.toString()
         )
-        viewModel.saveTransaction(transaction, updatedGoal)
-        findNavController().previousBackStackEntry?.savedStateHandle?.set(
-            "updated_goal",
-            updatedGoal
-        )
-
-        findNavController().popBackStack()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.saveTransaction(transaction, updatedGoal)
+            findNavController().previousBackStackEntry?.savedStateHandle?.set(
+                "updated_goal",
+                updatedGoal
+            )
+            findNavController().popBackStack()
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/WithdrawTransactionFragment.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/main/WithdrawTransactionFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import sl.kacinz.onluanmer.databinding.FragmentWithdrawTransactionBinding
 import sl.kacinz.onluanmer.domain.model.Transaction
@@ -60,14 +61,14 @@ class WithdrawTransactionFragment : Fragment() {
             comment = comment,
             date = binding.tvDate.text.toString()
         )
-        viewModel.saveTransaction(transaction, updatedGoal)
-
-        findNavController().previousBackStackEntry?.savedStateHandle?.set(
-            "updated_goal",
-            updatedGoal
-        )
-
-        findNavController().popBackStack()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.saveTransaction(transaction, updatedGoal)
+            findNavController().previousBackStackEntry?.savedStateHandle?.set(
+                "updated_goal",
+                updatedGoal
+            )
+            findNavController().popBackStack()
+        }
 
     }
 

--- a/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/viewmodels/AddTransactionViewModel.kt
+++ b/app/src/main/java/sl/kacinz/onluanmer/presentation/ui/fragments/viewmodels/AddTransactionViewModel.kt
@@ -1,9 +1,7 @@
 package sl.kacinz.onluanmer.presentation.ui.fragments.viewmodels
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import sl.kacinz.onluanmer.domain.model.Goal
 import sl.kacinz.onluanmer.domain.model.Transaction
 import sl.kacinz.onluanmer.domain.usecase.AddTransactionUseCase
@@ -13,7 +11,7 @@ import javax.inject.Inject
 class AddTransactionViewModel @Inject constructor(
     private val addTransactionUseCase: AddTransactionUseCase
 ) : ViewModel() {
-    fun saveTransaction(transaction: Transaction, goal: Goal) {
-        viewModelScope.launch { addTransactionUseCase(transaction, goal) }
+    suspend fun saveTransaction(transaction: Transaction, goal: Goal) {
+        addTransactionUseCase(transaction, goal)
     }
 }


### PR DESCRIPTION
## Summary
- ensure `AddTransactionViewModel.saveTransaction` suspends instead of launching its own coroutine
- call `saveTransaction` from the fragment's `lifecycleScope` so the DB update completes before navigating back

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fe3dd490832aa22b82b222f0a0eb